### PR TITLE
Fix typo that caused use of glyph 0 sometimes.

### DIFF
--- a/src/LayoutEngine.cpp
+++ b/src/LayoutEngine.cpp
@@ -66,7 +66,7 @@ icu_le_hb_font_get_glyph (hb_font_t *font,
     const LEFontInstance *fontInstance = (const LEFontInstance *) font_data;
 
     *glyph = fontInstance->mapCharToGlyph (unicode);
-    return !!glyph;
+    return !!*glyph;
 }
 
 static hb_position_t


### PR DESCRIPTION
There is a code that, as I assume, should check if glyph is 0 (which generally means "no glyph"), but instead it checks variable `glyph`. That variable is a pointer and it is unconditionally referenced a line before, so it never could be a null pointer.

This typo causes incorrect rendering at least with the Jozoor Arabic Font (https://fonts.jozoor.com/jozoor-font). After the fix it renders correctly.