### PR TITLE
Fix build with icu-68.1

### DIFF
--- a/src/LEFontInstance.cpp
+++ b/src/LEFontInstance.cpp
@@ -79,7 +79,7 @@ void LEFontInstance::mapCharsToGlyphs(const LEUnicode chars[], le_int32 offset, 
 
 LEGlyphID LEFontInstance::mapCharToGlyph(LEUnicode32 ch, const LECharMapper *mapper) const
 {
-    return mapCharToGlyph(ch, mapper, TRUE);
+    return mapCharToGlyph(ch, mapper, true);
 }
 
 LEGlyphID LEFontInstance::mapCharToGlyph(LEUnicode32 ch, const LECharMapper *mapper, le_bool filterZeroWidth) const

--- a/src/LEGlyphStorage.cpp
+++ b/src/LEGlyphStorage.cpp
@@ -659,7 +659,7 @@ le_bool LEGlyphStorage::applyInsertion(le_int32 atPosition, le_int32 count, LEGl
     // just got replaced by the insertion
     fSrcIndex -= 1;
 
-    return FALSE;
+    return false;
 }
 
 U_NAMESPACE_END

--- a/src/LEInsertionList.cpp
+++ b/src/LEInsertionList.cpp
@@ -86,11 +86,11 @@ le_bool LEInsertionList::applyInsertions(LEInsertionCallback *callback)
 {
     for (InsertionRecord *rec = head; rec != NULL; rec = rec->next) {
         if (callback->applyInsertion(rec->position, rec->count, rec->glyphs)) {
-            return TRUE;
+            return true;
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 U_NAMESPACE_END


### PR DESCRIPTION
icu-68.1 removed public macro definitions for TRUE and FALSE

See icu upstream commit: unicode-org/icu@a18df7b