### PR TITLE
Update to use the C++11 override specifier on virtual functions

### DIFF
--- a/src/LEFontInstance.h
+++ b/src/LEFontInstance.h
@@ -88,7 +88,7 @@ public:
      *
      * @stable ICU 2.8
      */
-    virtual ~LEFontInstance();
+    ~LEFontInstance() override;
 
     /**
      * Get a physical font which can render the given text. For composite fonts,
@@ -539,7 +539,7 @@ public:
      *
      * @stable ICU 3.2
      */
-    virtual UClassID getDynamicClassID() const;
+    UClassID getDynamicClassID() const override;
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for this class.

--- a/src/LEGlyphStorage.h
+++ b/src/LEGlyphStorage.h
@@ -107,7 +107,7 @@ protected:
      *
      * @stable ICU 3.0
      */
-    virtual le_bool applyInsertion(le_int32 atPosition, le_int32 count, LEGlyphID newGlyphs[]);
+    le_bool applyInsertion(le_int32 atPosition, le_int32 count, LEGlyphID newGlyphs[]) override;
 
 public:
 
@@ -125,7 +125,7 @@ public:
      *
      * @stable ICU 3.0
      */
-    ~LEGlyphStorage();
+    ~LEGlyphStorage() override;
 
     /**
      * This method returns the number of glyphs in the glyph array.
@@ -520,7 +520,7 @@ public:
      *
      * @stable ICU 3.0
      */
-    virtual UClassID getDynamicClassID() const;
+    UClassID getDynamicClassID() const override;
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for this class.

--- a/src/LEInsertionList.h
+++ b/src/LEInsertionList.h
@@ -76,7 +76,7 @@ public:
     /**
      * The destructor.
      */
-    ~LEInsertionList();
+    ~LEInsertionList() override;
 
     /**
      * Add an entry to the insertion list.
@@ -128,7 +128,7 @@ public:
      *
      * @stable ICU 2.8
      */
-    virtual UClassID getDynamicClassID() const;
+    UClassID getDynamicClassID() const override;
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for this class.

--- a/src/LayoutEngine.h
+++ b/src/LayoutEngine.h
@@ -97,7 +97,7 @@ public:
      *
      * @stable ICU 2.8
      */
-    ~LayoutEngine();
+    ~LayoutEngine() override;
 
     /**
      * This method will invoke the layout steps in their correct order by calling
@@ -255,7 +255,7 @@ public:
      *
      * @stable ICU 2.8
      */
-    virtual UClassID getDynamicClassID() const;
+    UClassID getDynamicClassID() const override;
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for this class.


### PR DESCRIPTION
ICU4C has required the use of C++11 since release 65.1 (October 2019).